### PR TITLE
Add README_AE.md for DevNet Automation Exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 
 Desktop application for deploying CE based device features to Webex Room devices.
 
-Deployment of the following features:
+Supports deployment of the following features:
+
 * Wallpapers
 * Macro Files
 * Touch 10 UI controls
@@ -13,15 +14,15 @@ Deployment of the following features:
 * Webex Board Touch 10 enablement
 * Disable Webex Assistant
 
-
 ## Business/Technical Challenge
 
-Not every feature and function of Webex Room devices is controllable from a administrative interface regardless of on-premise or in the cloud. 
-CE-Deploy helps to solve some of the most common or hard to deploy features at a large scale with a simple desktop tool.
-
+Not every feature and function of Webex Room devices is controllable from an administrative interface regardless of whether it is on-premise or in the cloud. 
+CE-Deploy helps to automate pushing some of the most common or hard to deploy features at a large scale with a simple desktop tool.
 
 ### Cisco Products Technologies/ Services
+
 CE-Deploy leverages the following technologies:
+
 * [Cisco Webex Room Devices](https://www.cisco.com/c/en/us/products/collaboration-endpoints/webex-room-series/index.html)
 * [Cisco Webex Cloud](https://collaborationhelp.cisco.com/article/en-us/n4lhv2s)
 * [Cisco Webex Room xAPI's](https://www.cisco.com/c/dam/en/us/td/docs/telepresence/endpoint/ce96/collaboration-endpoint-software-api-reference-guide-ce96.pdf)
@@ -35,29 +36,33 @@ CE-Deploy leverages the following technologies:
 
 ## Solution Components
 
-This solution is based on Electron which is built on JavaScript, Chrome and Nodejs.
-CE-Deploy is compatible with Cisco video devices running CE firmware 9.x and greater. Some
-features may support earlier versions of firmware including TC formware trains 
-but this has not been tested or supported.
+This solution is based on [Electron](https://www.electronjs.org/) which is built on JavaScript, Google Chrome and Nodejs.
 
-##Installation:
+CE-Deploy is compatible with Cisco video devices running CE firmware 9.x and greater. Some features may support earlier versions of firmware including TC firmware trains, but this has not been tested or supported.
 
-    git clone https://github.com/voipnorm/CE-Deploy.git
-    npm install
-    cd CE-Deploy
+## Installation:
+
+```bash
+git clone https://github.com/voipnorm/CE-Deploy.git
+npm install
+cd CE-Deploy
+```
     
 To run the project:
 
-    npm start
+```bash
+npm start
+```
 
 To perform a build:
 
-    npm run dist
-    
+```bash
+npm run dist
+```
+
 ## Usage
 
-CE-Deploy provides a desktop application for deploying the following features to CE 
-firmware based Cisco video endpoints in mass:
+CE-Deploy provides a desktop application for deploying the following features to CE firmware based Cisco video endpoints _en masse_:
 
 * Wallpapers
 * Macro Files
@@ -66,17 +71,18 @@ firmware based Cisco video endpoints in mass:
 * Digital Signage
 * Branding
 
-Many of these components can be deployed from CUCM or TMC but typically it is not an easy
-Task to perform or take multiple configuratio steps to complete. CE-Deploy makes it simple to 
-deploy to multiple endpoints.
+Many of these components can be deployed from CUCM or TMC but typically it is not an easy task to perform or takes multiple configuration steps to complete. CE-Deploy makes it simple to deploy to multiple endpoints.
 
 Components required to deploy various features:
 
 * CSV file with endpoints to be deployed.
 * Local user name and password for admin enabled account.
-## User Documentation
-User documentation for CE-Deploy is built into the tool. For reference check docs.html. 
 
-##License
+## User Documentation
+
+User documentation for CE-Deploy is built into the tool. For reference check `docs.html` 
+
+## License
+
 [CISCO SAMPLE CODE LICENSE](LICENSE.md) 
 

--- a/README_AE.md
+++ b/README_AE.md
@@ -1,0 +1,33 @@
+CE Feature Deployment Tool (CE-Deploy)
+=====================================
+Desktop application for deploying CE based device features to Webex Room devices.
+
+Supports deployment of the following features:
+
+* Wallpapers
+* Macro Files
+* Touch 10 UI controls
+* Download logs for troubleshooting
+* Digital Signage
+* Branding
+* Webex Board Touch 10 enablement
+* Disable Webex Assistant
+
+**Business/Technical Challenge**
+
+Not every feature and function of Webex Room devices is controllable from an administrative interface regardless of whether it is on-premise or in the cloud. 
+CE-Deploy helps to automate pushing some of the most common or hard to deploy features at a large scale with a simple desktop tool.
+
+## Related Sandbox
+
+[Roomkit CE Sandbox](https://devnetsandbox.cisco.com/RM/Diagram/Index/aada7ed1-18ed-491d-97ad-17ae3a11faba?diagramType=Topology)
+
+## Links to DevNet Learning Labs
+
+[Introduction to xAPI for Cisco collaboration devices](https://developer.cisco.com/learning/modules/webex_api_workshop/collab-xapi-intro/step/1)
+[Personalizing collaboration devices from code](https://developer.cisco.com/learning/modules/webex_api_workshop/collab-xapi-branding/step/1)
+[Creating custom in-room controls and Macros for Cisco collaboration devices](https://developer.cisco.com/learning/modules/webex_api_workshop/collab-xapi-controls/step/1)
+
+## Solutions on Ecosystem Exchange
+
+[InRoom-Macro-Deployer](https://developer.cisco.com/codeexchange/github/repo/voipnorm/InRoom-Macro-Deployer)


### PR DESCRIPTION
- README.md: small tweaks to grammar/formatting
- Add README_AE.md for DevNet Automation Exchange

I would like to propose including the awesome CE-Deploy project [currently on DevNet Code Exchange](https://developer.cisco.com/codeexchange/github/repo/voipnorm/InRoom-Macro-Deployer) to the Automation Exchange portal: [Automation Exchange](https://developer.cisco.com/network-automation/)

AE is a new(ish) portal promoting code samples/projects that provide a bit more than raw/abstract code samples, shading more towards useful as-is, out-of-the-box experiences - precisely what CE-Deploy is, IMHO.  I think this is a great way to spread the word and get more visibility, users, and perhaps contributors...

I am happy to create the AE submission, unless you prefer to do it yourself.  One small need is to have a GitHub-hosted file containing the AE project description.  I've taken the liberty of forking the CE-Deploy project, adding a README_AE.md file (based on the original README.md) and submitting a pull request.  

Hopefully the only action needed on your part would be to accept the PR, at which point I can finalize the AE submission.  (Note the PR has a few small grammar/layout tweaks to the original README.md too.)

Let me know if you have any questions/concerns.
